### PR TITLE
Fix search option condition

### DIFF
--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -338,7 +338,7 @@ class PluginResourcesTask extends CommonDBTM {
          'table'         => 'glpi_groups',
          'field'         => 'completename',
          'name'          => __('Group'),
-         'condition'     => '`is_assign`',
+         'condition'     => ['is_assign' => 1],
          'massiveaction' => false,
          'datatype'      => 'dropdown'
       ];


### PR DESCRIPTION
Updated to 9.5 style which is an array instead of a string.
This was the only remaining instance I could find. It looks like all the others were changed previously in this plugin.